### PR TITLE
v1.1.0: thermal printing, accurate session costs, and session matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,20 +38,31 @@ npx claude-receipts generate
 # Generate HTML (saved to ~/.claude-receipts/projects/)
 npx claude-receipts generate --output html
 
+# Print to thermal printer
+npx claude-receipts generate --output printer --printer usb
+
+# Multiple outputs (HTML + printer)
+npx claude-receipts generate --output html,printer
+
+# Specific session by UUID prefix
+npx claude-receipts generate --session 9356d5e2
+
 # Override location
 npx claude-receipts generate --location "Paris, France"
 ```
 
 **Options:**
 
-- `-s, --session <id>` - Generate for a specific session ID
-- `-o, --output <format>` - Output format: "html" or "console" (default: console)
+- `-s, --session <id>` - Generate for a specific session ID or UUID prefix
+- `-o, --output <format>` - Output format: "html", "console", or "printer" (supports multiple, comma-separated)
 - `-l, --location <text>` - Override location detection
+- `-p, --printer <name>` - Printer interface (e.g., "usb", "tcp://192.168.1.100")
 
 **Output Formats:**
 
 - `html` - Beautiful styled receipt saved to `~/.claude-receipts/projects/`
 - `console` - ASCII art display in terminal
+- `printer` - Send to thermal printer (requires Epson TM-T88V or compatible)
 
 ### `setup`
 
@@ -77,7 +88,8 @@ npx claude-receipts config --show
 
 # Set a configuration value
 npx claude-receipts config --set location="Kuala Lumpur, Malaysia"
-npx claude-receipts config --set enableConsole=true
+npx claude-receipts config --set timezone="Asia/Kuala_Lumpur"
+npx claude-receipts config --set printer=usb
 
 # Reset to defaults
 npx claude-receipts config --reset
@@ -87,6 +99,7 @@ npx claude-receipts config --reset
 
 - `location` - Default location (string)
 - `timezone` - Timezone for dates (string, e.g., "Asia/Macau")
+- `printer` - Default printer interface (string, e.g., "usb" or "tcp://192.168.1.100")
 
 ## Configuration
 
@@ -104,6 +117,7 @@ Configuration is stored at `~/.claude-receipts.config.json`.
 
 - `location` - Custom location string (otherwise auto-detected)
 - `timezone` - Custom timezone for date formatting
+- `printer` - Default printer interface for thermal printing
 
 ### Location Detection
 
@@ -116,17 +130,42 @@ Location is determined in this order:
 
 ## How It Works
 
-1. **SessionEnd Hook**: When you exit Claude Code, it calls `npx claude-receipts generate --output html` via stdin
-2. **Data Collection**: The package calls `ccusage` (bundled) to get session token/cost data
-3. **Transcript Parsing**: Reads the session transcript JSONL to extract metadata
-4. **Receipt Generation**: Bakes a HTML page with all the details on a styled receipt
-5. **Auto-open**: Opens the receipt in your default browser automatically
-6. **Auto-save**: Saves to `~/.claude-receipts/projects/[session-name].html`
+1. **SessionEnd Hook**: When you exit Claude Code, it calls `npx claude-receipts generate --output html` via stdin with the session ID
+2. **Data Collection**: The package calls `ccusage session --id <session-id>` to get accurate session token/cost data
+3. **Transcript Parsing**: Reads the session transcript JSONL to extract metadata (session name, timestamps, message count)
+
+### HTML output
+
+4. **Receipt Generation**: If `--output html` is specified, generates a styled HTML receipt with token breakdowns by model
+5. **Output**: Saves HTML to `~/.claude-receipts/projects/[session-name].html` and/or prints to thermal printer
+6. **Auto-open**: Opens the HTML receipt in your default browser automatically (hook mode only)
+
+### Printer output
+
+1. **Thermal Printing**: If `--output printer` is specified, sends the receipt to a thermal receipt printer
 
 ## Requirements
 
 - Node.js >= 22.0.0
 - Claude Code (for automatic generation)
+
+## Thermal Printing
+
+claude-receipts supports printing to Epson TM-T88V thermal printers (and compatible models) via:
+
+- **USB**: Auto-detect via `--printer usb` (or `config --set printer=usb`)
+- **Network**: Direct TCP via `--printer tcp://192.168.1.100`
+
+> [!WARNING]
+> Your mileage with printing may vary. I have tested with an Epson TM-T88V, printing from macOS and it works well, but other models may have different capabilities or require adjustments to the code. I am more than happy to accept PRs to improve printer compatibility.
+
+The receipt includes:
+
+- Claude ASCII logo
+- Session details and location
+- Token breakdown by model (input, output, cache read/write)
+- Total cost
+- QR code linking to the GitHub repo
 
 ## Troubleshooting
 
@@ -155,14 +194,30 @@ cat ~/.claude/settings.json
 
 You should see a `SessionEnd` hook pointing to `claude-receipts`.
 
+### Session shows wrong cost or is missing
+
+Very short sessions (e.g., just "hello world" + immediate exit) may not appear in ccusage yet. The hook will exit silently rather than printing a wrong receipt. For sessions that exist, the package now uses `ccusage session --id` to fetch accurate totals rather than sub-session slices.
+
+### Printer not found
+
+If using `--printer usb`, ensure:
+
+- Printer is connected via USB
+- Printer is an Epson TM-T88V or compatible ESC/POS model
+- On Linux, you may need permission to access USB devices (`/dev/usb/lp*`)
+
+For network printers, use `--printer tcp://<ip-address>` with port 9100 (default ESC/POS port).
+
 ## Contributing
 
 ## Roadmap
 
 - [x] HTML receipts with auto-open in browser
 - [x] Console ASCII art mode
-- [ ] Image export
-- [ ] Real receipt printing
+- [x] Real thermal receipt printing (Epson TM-T88V)
+- [x] Accurate session cost tracking (via `ccusage --id`)
+- [x] Session matching by UUID or prefix
+- [ ] Image export (PNG/JPEG)
 - [ ] Plugin for Opencode ([opencode issue](https://github.com/anomalyco/opencode/issues/10524))
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "fs-extra": "^11.3.3",
         "geoip-lite": "^1.4.10",
         "ora": "^9.1.0",
-        "prompts": "^2.4.2"
+        "prompts": "^2.4.2",
+        "usb": "^2.17.0"
       },
       "bin": {
         "claude-receipts": "bin/claude-receipts.js"
@@ -101,6 +102,12 @@
         "@types/node": "*",
         "kleur": "^3.0.3"
       }
+    },
+    "node_modules/@types/w3c-web-usb": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.13.tgz",
+      "integrity": "sha512-N2nSl3Xsx8mRHZBvMSdNGtzMyeleTvtlEw+ujujgXalPqOjIA6UtrqcB6OzyUjkTbDm3J7P1RNK1lgoO7jxtsw==",
+      "license": "MIT"
     },
     "node_modules/ansi-align": {
       "version": "3.0.1",
@@ -763,6 +770,26 @@
         "node": "*"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
@@ -1117,6 +1144,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/usb": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.17.0.tgz",
+      "integrity": "sha512-UuFgrlglgDn5ll6d5l7kl3nDb2Yx43qLUGcDq+7UNLZLtbNug0HZBb2Xodhgx2JZB1LqvU+dOGqLEeYUeZqsHg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^8.0.0",
+        "node-gyp-build": "^4.5.0"
+      },
+      "engines": {
+        "node": ">=12.22.0 <13.0 || >=14.17.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-receipts",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Bring receipts from your Claude Code sessions",
   "license": "MIT",
   "author": "Chris Hutchinson <github.com/chrishutchinson>",
@@ -50,7 +50,8 @@
     "fs-extra": "^11.3.3",
     "geoip-lite": "^1.4.10",
     "ora": "^9.1.0",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "usb": "^2.17.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { Command } from "commander";
+import { Command, Option } from "commander";
 import { GenerateCommand } from "./commands/generate.js";
 import { ConfigCommand } from "./commands/config.js";
 import { SetupCommand } from "./commands/setup.js";
@@ -17,12 +17,24 @@ program
   .command("generate")
   .description("Generate a receipt for a Claude Code session")
   .option("-s, --session <id>", "Specific session ID to generate receipt for")
-  .option(
-    "-o, --output <format>",
-    'Output format: "html" or "console" (default: console)',
-    "console",
+  .addOption(
+    new Option("-o, --output <format...>", "Output format(s): html, console, printer (comma-separated or repeated)")
+      .argParser((value: string, prev: string[] | undefined) => {
+        const formats = value.split(",").map((s) => s.trim()).filter(Boolean);
+        const valid = ["html", "console", "printer"];
+        for (const f of formats) {
+          if (!valid.includes(f)) {
+            throw new Error(`Invalid output format "${f}". Valid formats: ${valid.join(", ")}`);
+          }
+        }
+        return [...(prev || []), ...formats];
+      }),
   )
   .option("-l, --location <text>", "Override location detection")
+  .option(
+    "-p, --printer <interface>",
+    'Printer: "usb" (auto-detect), "usb:VID:PID", "tcp://host:port", or CUPS name',
+  )
   .action(async (options) => {
     const command = new GenerateCommand();
     await command.execute(options);

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -56,6 +56,7 @@ export class ConfigCommand {
     this.printConfigItem("Version", config.version);
     this.printConfigItem("Location", config.location || "(auto-detect)");
     this.printConfigItem("Timezone", config.timezone || "(system default)");
+    this.printConfigItem("Printer", config.printer || "(not set)");
 
     console.log("");
   }
@@ -74,7 +75,7 @@ export class ConfigCommand {
     const trimmedKey = key.trim() as keyof ReceiptConfig;
 
     // Validate key
-    const validKeys: (keyof ReceiptConfig)[] = ["location", "timezone"];
+    const validKeys: (keyof ReceiptConfig)[] = ["location", "timezone", "printer"];
 
     if (!validKeys.includes(trimmedKey)) {
       throw new Error(

--- a/src/core/data-fetcher.ts
+++ b/src/core/data-fetcher.ts
@@ -1,20 +1,137 @@
 import { execa } from "execa";
-import type { CcusageResponse, CcusageSession } from "../types/ccusage.js";
+import type {
+  CcusageResponse,
+  CcusageSession,
+  ModelBreakdown,
+} from "../types/ccusage.js";
+
+interface CcusageEntry {
+  timestamp: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheCreationTokens?: number;
+  cacheReadTokens?: number;
+  model: string;
+  costUSD: number;
+}
+
+interface CcusageByIdResponse {
+  sessionId: string;
+  totalCost: number;
+  totalTokens: number;
+  entries: CcusageEntry[];
+}
 
 export class DataFetcher {
   /**
-   * Fetch session data from ccusage CLI
+   * Fetch accurate session data by exact session ID.
+   * Uses `ccusage session --id` which returns the true total cost
+   * (unlike --breakdown which splits into sub-session slices).
    */
-  async fetchSessionData(sessionId?: string): Promise<CcusageSession> {
+  async fetchSessionById(sessionId: string): Promise<CcusageSession> {
+    const { stdout } = await execa(
+      "npx",
+      ["ccusage", "session", "--id", sessionId, "--json"],
+      { timeout: 30000 },
+    );
+
+    const data: CcusageByIdResponse = JSON.parse(stdout);
+
+    // Aggregate entries by model
+    const modelMap = new Map<
+      string,
+      {
+        inputTokens: number;
+        outputTokens: number;
+        cacheCreationTokens: number;
+        cacheReadTokens: number;
+        totalTokens: number;
+      }
+    >();
+
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCacheCreation = 0;
+    let totalCacheRead = 0;
+
+    for (const entry of data.entries) {
+      // Skip synthetic entries (no real model)
+      if (entry.model === "<synthetic>") continue;
+
+      const input = entry.inputTokens || 0;
+      const output = entry.outputTokens || 0;
+      const cacheCreation = entry.cacheCreationTokens || 0;
+      const cacheRead = entry.cacheReadTokens || 0;
+
+      totalInput += input;
+      totalOutput += output;
+      totalCacheCreation += cacheCreation;
+      totalCacheRead += cacheRead;
+
+      const existing = modelMap.get(entry.model) || {
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheCreationTokens: 0,
+        cacheReadTokens: 0,
+        totalTokens: 0,
+      };
+
+      existing.inputTokens += input;
+      existing.outputTokens += output;
+      existing.cacheCreationTokens += cacheCreation;
+      existing.cacheReadTokens += cacheRead;
+      existing.totalTokens += input + output + cacheCreation + cacheRead;
+      modelMap.set(entry.model, existing);
+    }
+
+    // Distribute totalCost across models proportionally by token count
+    const totalTokensAcrossModels = [...modelMap.values()].reduce(
+      (sum, m) => sum + m.totalTokens,
+      0,
+    );
+
+    const modelBreakdowns: ModelBreakdown[] = [...modelMap.entries()].map(
+      ([modelName, stats]) => ({
+        modelName,
+        inputTokens: stats.inputTokens,
+        outputTokens: stats.outputTokens,
+        cacheCreationTokens: stats.cacheCreationTokens,
+        cacheReadTokens: stats.cacheReadTokens,
+        cost:
+          totalTokensAcrossModels > 0
+            ? data.totalCost * (stats.totalTokens / totalTokensAcrossModels)
+            : 0,
+      }),
+    );
+
+    return {
+      sessionId: data.sessionId,
+      inputTokens: totalInput,
+      outputTokens: totalOutput,
+      cacheCreationTokens: totalCacheCreation,
+      cacheReadTokens: totalCacheRead,
+      totalTokens: data.totalTokens,
+      totalCost: data.totalCost,
+      modelsUsed: [...modelMap.keys()],
+      modelBreakdowns,
+    };
+  }
+
+  /**
+   * Discover a session from the ccusage breakdown list, then fetch accurate
+   * data via --id.
+   *
+   * @param sessionQuery Optional filter — matches against:
+   *   1. Project path UUID (or prefix, e.g. "5ede5ccb")
+   *   2. Session name (e.g. "subagents") — picks the most recent match
+   *   If omitted, returns the first session with a valid project path.
+   */
+  async fetchSessionData(sessionQuery?: string): Promise<CcusageSession> {
     try {
       const args = ["session", "--json", "--breakdown"];
 
-      if (sessionId) {
-        args.push("--id", sessionId);
-      }
-
       const { stdout } = await execa("npx", ["ccusage", ...args], {
-        timeout: 30000, // 30 second timeout
+        timeout: 30000,
       });
 
       const response: CcusageResponse = JSON.parse(stdout);
@@ -23,23 +140,64 @@ export class DataFetcher {
         throw new Error("No session data found");
       }
 
-      // If no session ID specified, find the first session with a valid project path
-      if (!sessionId) {
-        const validSession = response.sessions.find(
-          (s) => s.projectPath && s.projectPath !== "Unknown Project",
+      const validSessions = response.sessions.filter(
+        (s) => s.projectPath && s.projectPath !== "Unknown Project",
+      );
+
+      if (validSessions.length === 0) {
+        throw new Error(
+          "No sessions with valid project paths found. Please run this command from a SessionEnd hook.",
         );
-
-        if (!validSession) {
-          throw new Error(
-            "No sessions with valid project paths found. Please run this command from a SessionEnd hook.",
-          );
-        }
-
-        return validSession;
       }
 
-      // Return the first session (should match the ID if specified)
-      return response.sessions[0];
+      let match: CcusageSession | undefined;
+
+      if (!sessionQuery) {
+        match = validSessions[0];
+      } else {
+        // Try matching by project path UUID (exact or prefix)
+        match = validSessions.find((s) => {
+          const uuid = s.projectPath!.split("/").pop() || "";
+          return uuid === sessionQuery || uuid.startsWith(sessionQuery);
+        });
+
+        // Try matching by session name (returns first/most recent match)
+        if (!match) {
+          match = validSessions.find((s) => s.sessionId === sessionQuery);
+        }
+      }
+
+      if (!match) {
+        const available = validSessions
+          .slice(0, 10)
+          .map((s) => {
+            const uuid = s.projectPath!.split("/").pop() || "";
+            const short = uuid.slice(0, 8);
+            return `  ${short}  ${s.sessionId.padEnd(20)}  $${s.totalCost.toFixed(2)}`;
+          })
+          .join("\n");
+
+        throw new Error(
+          `No session matching "${sessionQuery}". Available sessions:\n${available}`,
+        );
+      }
+
+      // Extract the full UUID from the projectPath and re-fetch via --id
+      // for accurate totals (--breakdown only shows sub-session slices)
+      const fullUuid = match.projectPath!.split("/").pop();
+      if (fullUuid) {
+        try {
+          const accurate = await this.fetchSessionById(fullUuid);
+          // Preserve projectPath from the discovery result
+          accurate.projectPath = match.projectPath;
+          return accurate;
+        } catch {
+          // Fall back to breakdown data if --id fails
+          return match;
+        }
+      }
+
+      return match;
     } catch (error) {
       if (error instanceof Error) {
         throw new Error(`Failed to fetch session data: ${error.message}`);

--- a/src/core/thermal-printer.ts
+++ b/src/core/thermal-printer.ts
@@ -1,0 +1,476 @@
+import { createConnection } from "net";
+import { exec } from "child_process";
+import { promisify } from "util";
+import type { ReceiptData } from "./receipt-generator.js";
+import {
+  formatCurrency,
+  formatNumber,
+  formatDateTime,
+} from "../utils/formatting.js";
+
+const execAsync = promisify(exec);
+
+const WIDTH = 40; // TM-T88V 80mm paper, Font A minus margin
+const LEFT_MARGIN_DOTS = 12; // 1 character width at 203 dpi
+
+const REPO_URL = "https://github.com/chrishutchinson/claude-receipts";
+
+// Epson USB vendor ID
+const EPSON_VENDOR_ID = 0x04b8;
+// TM-T88V product ID
+const TM_T88V_PRODUCT_ID = 0x0202;
+
+// ESC/POS command constants
+const ESC = 0x1b;
+const GS = 0x1d;
+const LF = 0x0a;
+
+// CP437 block characters (raw byte values — not UTF-8)
+const BLK = 0xdb; // █ full block
+const UPH = 0xdf; // ▀ upper half block
+const LFH = 0xdd; // ▌ left half block
+const RHF = 0xde; // ▐ right half block
+
+/** Tiny buffer builder for ESC/POS byte sequences. */
+class EscPosBuilder {
+  private chunks: Buffer[] = [];
+
+  /** Append raw bytes. */
+  raw(...bytes: number[]): this {
+    this.chunks.push(Buffer.from(bytes));
+    return this;
+  }
+
+  /** Append a UTF-8 string (no newline). */
+  text(s: string): this {
+    this.chunks.push(Buffer.from(s, "utf-8"));
+    return this;
+  }
+
+  /** Append a string followed by LF. */
+  line(s: string = ""): this {
+    return this.text(s).raw(LF);
+  }
+
+  /** ESC @ — initialize printer. */
+  init(): this {
+    return this.raw(ESC, 0x40);
+  }
+
+  /** GS L nL nH — set left margin in motion units (1/203 inch). */
+  leftMargin(dots: number): this {
+    return this.raw(GS, 0x4c, dots & 0xff, (dots >> 8) & 0xff);
+  }
+
+  /**
+   * Print the Claude logo using CP437 block characters.
+   * 5-row character: solid head, eyes, wider arms, solid body, legs.
+   */
+  logo(): this {
+    this.align("center");
+    // Row 1 (solid head):  ▐██████████▌
+    this.raw(RHF, BLK, BLK, BLK, BLK, BLK, BLK, BLK, BLK, BLK, BLK, LFH, LF);
+    // Row 2 (eyes):        ██ ██ ██
+    this.raw(RHF, BLK, BLK, 0x20, BLK, BLK, BLK, BLK, 0x20, BLK, BLK, LFH, LF);
+    // Row 3 (arms, wider): ▐████████▌
+    this.raw(
+      RHF,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      BLK,
+      LFH,
+      LF,
+    );
+    // Row 4 (solid body):  ▐██████▌
+    this.raw(RHF, BLK, BLK, BLK, BLK, BLK, BLK, BLK, BLK, BLK, BLK, LFH, LF);
+    // Row 5 (legs):         ▀▀  ▀▀
+    this.raw(UPH, 0x20, UPH, 0x20, 0x20, UPH, 0x20, UPH, LF);
+    return this;
+  }
+
+  /** ESC E n — bold on/off. */
+  bold(on: boolean): this {
+    return this.raw(ESC, 0x45, on ? 1 : 0);
+  }
+
+  /** ESC a n — alignment (0=left, 1=center, 2=right). */
+  align(mode: "left" | "center" | "right"): this {
+    const n = mode === "left" ? 0 : mode === "center" ? 1 : 2;
+    return this.raw(ESC, 0x61, n);
+  }
+
+  /**
+   * ESC ! n — select print mode.
+   *   bit 3 = double height, bit 4 = double width, bit 5 = bold
+   *   0x00 = normal, 0x30 = double-height + double-width
+   */
+  printMode(n: number): this {
+    return this.raw(ESC, 0x21, n);
+  }
+
+  /** Convenience: double-height + double-width text. */
+  doubleSize(): this {
+    return this.printMode(0x30);
+  }
+
+  /** Convenience: reset to normal size. */
+  normalSize(): this {
+    return this.printMode(0x00);
+  }
+
+  /** Print a full line of a repeated character. */
+  drawLine(char: string = "="): this {
+    return this.line(char.repeat(WIDTH));
+  }
+
+  /** Print a two-column row: left-aligned label, right-aligned value. */
+  leftRight(left: string, right: string): this {
+    const gap = WIDTH - left.length - right.length;
+    if (gap < 1) {
+      return this.line(`${left} ${right}`);
+    }
+    return this.line(`${left}${" ".repeat(gap)}${right}`);
+  }
+
+  /**
+   * QR code via GS ( k commands (Epson model 2).
+   *   1) Select model 2
+   *   2) Set cell size
+   *   3) Set error correction (M)
+   *   4) Store data
+   *   5) Print stored data
+   */
+  qrCode(data: string, cellSize: number = 6): this {
+    const d = Buffer.from(data, "utf-8");
+
+    // Function 165 — select QR model 2
+    this.raw(GS, 0x28, 0x6b, 4, 0, 0x31, 0x41, 50, 0);
+    // Function 167 — set cell size
+    this.raw(GS, 0x28, 0x6b, 3, 0, 0x31, 0x43, cellSize);
+    // Function 169 — error correction level M (49)
+    this.raw(GS, 0x28, 0x6b, 3, 0, 0x31, 0x45, 49);
+    // Function 180 — store data
+    const storeLen = d.length + 3;
+    this.raw(
+      GS,
+      0x28,
+      0x6b,
+      storeLen & 0xff,
+      (storeLen >> 8) & 0xff,
+      0x31,
+      0x50,
+      0x30,
+    );
+    this.chunks.push(d);
+    // Function 181 — print
+    this.raw(GS, 0x28, 0x6b, 3, 0, 0x31, 0x51, 0x30);
+
+    return this;
+  }
+
+  /** GS V 66 3 — partial cut with feed. */
+  partialCut(): this {
+    return this.raw(GS, 0x56, 0x42, 3);
+  }
+
+  /** Return the complete buffer. */
+  build(): Buffer {
+    return Buffer.concat(this.chunks);
+  }
+}
+
+export class ThermalPrinterRenderer {
+  /**
+   * Print a receipt to a thermal printer.
+   *
+   * Supported interface formats:
+   *   - "tcp://host:port" — send via TCP socket
+   *   - "usb" — auto-detect Epson TM-T88V via libusb
+   *   - "usb:VID:PID" — specific USB vendor/product ID (hex)
+   *   - anything else — treated as a CUPS printer name
+   */
+  async printReceipt(
+    data: ReceiptData,
+    printerInterface: string,
+    shareUrl?: string,
+  ): Promise<void> {
+    const buffer = this.buildReceipt(data, shareUrl);
+
+    if (printerInterface.startsWith("tcp://")) {
+      await this.sendViaTcp(buffer, printerInterface);
+    } else if (
+      printerInterface === "usb" ||
+      printerInterface.startsWith("usb:")
+    ) {
+      await this.sendViaUsb(buffer, printerInterface);
+    } else {
+      await this.sendViaCups(buffer, printerInterface);
+    }
+  }
+
+  /**
+   * Build the full ESC/POS receipt buffer.
+   */
+  private buildReceipt(data: ReceiptData, shareUrl?: string): Buffer {
+    const b = new EscPosBuilder();
+
+    b.init();
+    b.leftMargin(LEFT_MARGIN_DOTS);
+
+    // --- Header ---
+    b.logo();
+    b.line();
+
+    // --- Info ---
+    b.align("center");
+    b.line(`Location: ${data.location}`);
+    b.line(`Session: ${data.transcriptData.sessionSlug}`);
+    b.line(formatDateTime(data.transcriptData.endTime, data.config.timezone));
+    b.line();
+
+    // --- Model breakdowns ---
+    b.align("left");
+    b.drawLine();
+
+    if (
+      data.sessionData.modelBreakdowns &&
+      data.sessionData.modelBreakdowns.length > 0
+    ) {
+      for (const model of data.sessionData.modelBreakdowns) {
+        // Model name with its cost
+        b.bold(true);
+        b.leftRight(
+          this.getModelName(model.modelName),
+          formatCurrency(model.cost),
+        );
+        b.bold(false);
+        b.drawLine("-");
+
+        // Token counts (no prices)
+        b.leftRight("  Input tokens", formatNumber(model.inputTokens));
+        b.leftRight("  Output tokens", formatNumber(model.outputTokens));
+
+        if (model.cacheCreationTokens && model.cacheCreationTokens > 0) {
+          b.leftRight("  Cache write", formatNumber(model.cacheCreationTokens));
+        }
+
+        if (model.cacheReadTokens && model.cacheReadTokens > 0) {
+          b.leftRight("  Cache read", formatNumber(model.cacheReadTokens));
+        }
+
+        b.line();
+
+        b.drawLine();
+      }
+    }
+
+    // --- Total ---
+    b.bold(true);
+    b.leftRight("TOTAL", formatCurrency(data.sessionData.totalCost));
+    b.bold(false);
+    b.drawLine();
+    b.line();
+
+    // --- Footer ---
+    b.align("left");
+    b.line(`CASHIER: ${this.getMainModel(data.sessionData)}`);
+    b.line();
+    b.align("center");
+    b.line("Thank you for building!");
+    b.line();
+
+    // --- Repo QR code ---
+    b.align("center");
+    b.line("Print your own Claude receipts:");
+    b.qrCode(REPO_URL, 4);
+    b.line("github.com/chrishutchinson");
+    b.line("/claude-receipts");
+    b.line();
+
+    // --- Cut ---
+    b.partialCut();
+
+    return b.build();
+  }
+
+  /**
+   * Send buffer to a network printer via TCP.
+   */
+  private sendViaTcp(buffer: Buffer, address: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const url = new URL(address);
+      const host = url.hostname;
+      const port = parseInt(url.port || "9100", 10);
+
+      const socket = createConnection({ host, port }, () => {
+        socket.end(buffer, () => {
+          resolve();
+        });
+      });
+
+      socket.on("error", (err) => {
+        reject(new Error(`TCP printer connection failed: ${err.message}`));
+      });
+    });
+  }
+
+  /**
+   * Send buffer directly to a USB printer via libusb.
+   *
+   * @param buffer ESC/POS data
+   * @param spec "usb" for auto-detect, or "usb:VID:PID" for specific device
+   */
+  private async sendViaUsb(buffer: Buffer, spec: string): Promise<void> {
+    const { findByIds, getDeviceList, OutEndpoint } = await import("usb");
+
+    let vid = EPSON_VENDOR_ID;
+    let pid = TM_T88V_PRODUCT_ID;
+
+    // Parse "usb:VID:PID" if provided
+    if (spec.startsWith("usb:")) {
+      const parts = spec.split(":");
+      if (parts.length >= 3) {
+        vid = parseInt(parts[1], 16);
+        pid = parseInt(parts[2], 16);
+      }
+    }
+
+    const device = findByIds(vid, pid);
+    if (!device) {
+      // List what USB devices we can see to help debug
+      const devices = getDeviceList();
+      const summary = devices
+        .slice(0, 10)
+        .map(
+          (d) =>
+            `  ${d.deviceDescriptor.idVendor.toString(16)}:${d.deviceDescriptor.idProduct.toString(16)}`,
+        )
+        .join("\n");
+
+      throw new Error(
+        `USB printer not found (looking for ${vid.toString(16)}:${pid.toString(16)}).\n` +
+          `Visible USB devices:\n${summary || "  (none)"}`,
+      );
+    }
+
+    device.open();
+
+    try {
+      const iface = device.interface(0);
+
+      // Detach kernel driver if active (e.g. macOS claiming the device)
+      if (iface.isKernelDriverActive()) {
+        iface.detachKernelDriver();
+      }
+
+      iface.claim();
+
+      // Find the OUT endpoint (bulk transfer to printer)
+      const outEndpoint = iface.endpoints.find(
+        (ep): ep is InstanceType<typeof OutEndpoint> =>
+          ep instanceof OutEndpoint,
+      );
+
+      if (!outEndpoint) {
+        throw new Error(
+          "No OUT endpoint found on USB interface 0. " +
+            `Endpoints: ${iface.endpoints.map((e) => `${e.address} (${e.direction})`).join(", ")}`,
+        );
+      }
+
+      // Send the data
+      await outEndpoint.transferAsync(buffer);
+
+      await iface.releaseAsync();
+    } finally {
+      device.close();
+    }
+  }
+
+  /**
+   * Send raw ESC/POS buffer to a CUPS printer via `lp`.
+   */
+  private async sendViaCups(
+    buffer: Buffer,
+    printerName: string,
+  ): Promise<void> {
+    // Verify the CUPS destination exists before attempting to print.
+    // `lp` gives a misleading "No such file or directory" when the
+    // printer name doesn't match any CUPS destination.
+    try {
+      await execAsync(`lpstat -p "${printerName}"`);
+    } catch {
+      let available = "";
+      try {
+        const { stdout } = await execAsync("lpstat -p");
+        const names = stdout
+          .split("\n")
+          .filter((l) => l.startsWith("printer "))
+          .map((l) => l.split(" ")[1]);
+        if (names.length > 0) {
+          available = `\nAvailable printers: ${names.join(", ")}`;
+        }
+      } catch {
+        // lpstat itself failed — no CUPS printers at all
+      }
+
+      throw new Error(
+        `Printer "${printerName}" not found in CUPS.${available || "\nNo printers are configured. Add one via System Settings > Printers & Scanners."}`,
+      );
+    }
+
+    const { writeFile, unlink } = await import("fs/promises");
+    const { join } = await import("path");
+    const { tmpdir } = await import("os");
+
+    const tmpFile = join(tmpdir(), `claude-receipt-${Date.now()}.bin`);
+
+    try {
+      await writeFile(tmpFile, buffer);
+      await execAsync(`lp -d "${printerName}" -o raw "${tmpFile}"`);
+    } finally {
+      try {
+        await unlink(tmpFile);
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+  }
+
+  private getModelName(model: string): string {
+    const cleaned = model.replace(/-\d{8}$/, "");
+
+    const modelMap: Record<string, string> = {
+      "claude-sonnet-4-5": "Claude Sonnet 4.5",
+      "claude-opus-4-5": "Claude Opus 4.5",
+      "claude-3-5-sonnet": "Claude 3.5 Sonnet",
+      "claude-3-opus": "Claude 3 Opus",
+      "claude-3-haiku": "Claude 3 Haiku",
+    };
+
+    return modelMap[cleaned] || model;
+  }
+
+  private getMainModel(sessionData: ReceiptData["sessionData"]): string {
+    if (sessionData.modelBreakdowns && sessionData.modelBreakdowns.length > 0) {
+      return this.getModelName(sessionData.modelBreakdowns[0].modelName);
+    }
+
+    if (sessionData.modelsUsed && sessionData.modelsUsed.length > 0) {
+      return this.getModelName(sessionData.modelsUsed[0]);
+    }
+
+    return "Claude";
+  }
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -4,6 +4,7 @@ export interface ReceiptConfig {
   version: string;
   location?: string;
   timezone?: string;
+  printer?: string;
 }
 
 export const DEFAULT_CONFIG: ReceiptConfig = {


### PR DESCRIPTION
- Add thermal printer support (Epson TM-T88V) via USB and TCP
- Fix session cost accuracy: use `ccusage --id` instead of `--breakdown` which was returning sub-session slices instead of true totals
- Fix hook mode: pass session ID from stdin to ccusage so we match the correct session instead of returning an arbitrary one
- Silently skip receipt generation for sessions not yet in ccusage (e.g. very short sessions) rather than printing wrong data
- Support multiple output formats (html,console,printer) comma-separated
- Add printer config option and CLI flag
- Update setup wizard with output format selection
- Add GitHub URL below QR code on printed receipts
- Update README with thermal printing docs and new troubleshooting sections