### PR TITLE
Fix Windows path separator handling

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -1,3 +1,4 @@
+import { basename, join } from "path";
 import { stdin } from "process";
 import chalk from "chalk";
 import boxen from "boxen";
@@ -85,11 +86,10 @@ export class GenerateCommand {
           sessionData.projectPath &&
           sessionData.projectPath !== "Unknown Project"
         ) {
-          const parts = sessionData.projectPath.split("/");
-          actualSessionId = parts[parts.length - 1]; // Last part is the actual session ID
+          actualSessionId = basename(sessionData.projectPath);
 
           const home = process.env.HOME || process.env.USERPROFILE || "";
-          transcriptPath = `${home}/.claude/projects/${sessionData.projectPath}.jsonl`;
+          transcriptPath = join(home, ".claude", "projects", sessionData.projectPath + ".jsonl");
         } else {
           throw new Error(
             "Cannot determine transcript path. Session has no valid project path.",
@@ -211,8 +211,8 @@ export class GenerateCommand {
   ): Promise<void> {
     const fileName = sessionSlug || sessionId;
     const home = process.env.HOME || process.env.USERPROFILE || "";
-    const outputDir = `${home}/.claude-receipts/projects`;
-    const fullPath = `${outputDir}/${fileName}.html`;
+    const outputDir = join(home, ".claude-receipts", "projects");
+    const fullPath = join(outputDir, `${fileName}.html`);
 
     const html = this.htmlRenderer.generateHtml(receiptData, receipt);
     await this.saveHtmlFile(html, fullPath);

--- a/src/core/data-fetcher.ts
+++ b/src/core/data-fetcher.ts
@@ -1,3 +1,4 @@
+import { basename } from "path";
 import { execa } from "execa";
 import type {
   CcusageResponse,
@@ -157,7 +158,7 @@ export class DataFetcher {
       } else {
         // Try matching by project path UUID (exact or prefix)
         match = validSessions.find((s) => {
-          const uuid = s.projectPath!.split("/").pop() || "";
+          const uuid = basename(s.projectPath!);
           return uuid === sessionQuery || uuid.startsWith(sessionQuery);
         });
 
@@ -171,7 +172,7 @@ export class DataFetcher {
         const available = validSessions
           .slice(0, 10)
           .map((s) => {
-            const uuid = s.projectPath!.split("/").pop() || "";
+            const uuid = basename(s.projectPath!);
             const short = uuid.slice(0, 8);
             return `  ${short}  ${s.sessionId.padEnd(20)}  $${s.totalCost.toFixed(2)}`;
           })
@@ -184,7 +185,7 @@ export class DataFetcher {
 
       // Extract the full UUID from the projectPath and re-fetch via --id
       // for accurate totals (--breakdown only shows sub-session slices)
-      const fullUuid = match.projectPath!.split("/").pop();
+      const fullUuid = basename(match.projectPath!);
       if (fullUuid) {
         try {
           const accurate = await this.fetchSessionById(fullUuid);

--- a/src/core/transcript-parser.ts
+++ b/src/core/transcript-parser.ts
@@ -11,7 +11,7 @@ export class TranscriptParser {
    */
   async parseTranscript(transcriptPath: string): Promise<ParsedTranscript> {
     // Expand ~ to home directory
-    const expandedPath = transcriptPath.replace(/^~/, process.env.HOME || "");
+    const expandedPath = transcriptPath.replace(/^~/, process.env.HOME || process.env.USERPROFILE || "");
 
     if (!existsSync(expandedPath)) {
       throw new Error(`Transcript file not found: ${transcriptPath}`);


### PR DESCRIPTION
## Summary

- Replace `split("/").pop()` with `path.basename()` for extracting session UUIDs from `projectPath` in `data-fetcher.ts` and `generate.ts`
- Replace string-concatenated paths with `path.join()` for transcript and output file paths
- Add `USERPROFILE` env var fallback in `transcript-parser.ts` (Windows equivalent of `HOME`)

## Problem

On Windows, `ccusage` returns `projectPath` values with backslash separators (e.g. `"C--Repos-project\beb62166-f980-44a0-8a02-baf67a0187be"`). The existing `split("/").pop()` calls return the entire string rather than just the UUID, so session matching always fails.

## Test plan

- Tested on Windows 11 with `node dist/cli.js generate --output console` — successfully finds and renders sessions
- Tested SessionEnd hook with `--output html` — receipt opens in browser
- Build passes with no errors