### PR TITLE
security: fix command injection and HTML injection

### DIFF
--- a/src/commands/generate.ts
+++ b/src/commands/generate.ts
@@ -2,7 +2,7 @@ import { stdin } from "process";
 import chalk from "chalk";
 import boxen from "boxen";
 import ora from "ora";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 import { DataFetcher } from "../core/data-fetcher.js";
 import { TranscriptParser } from "../core/transcript-parser.js";
@@ -14,7 +14,7 @@ import { LocationDetector } from "../utils/location.js";
 import type { SessionEndHookData } from "../types/session-hook.js";
 import type { ReceiptData } from "../core/receipt-generator.js";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export type OutputFormat = "html" | "console" | "printer";
 
@@ -332,18 +332,14 @@ export class GenerateCommand {
 
     try {
       if (platform === "darwin") {
-        // macOS
-        await execAsync(`open "${filePath}"`);
+        await execFileAsync("open", [filePath]);
       } else if (platform === "win32") {
-        // Windows
-        await execAsync(`start "" "${filePath}"`);
+        await execFileAsync("cmd", ["/c", "start", "", filePath]);
       } else {
-        // Linux
-        await execAsync(`xdg-open "${filePath}"`);
+        await execFileAsync("xdg-open", [filePath]);
       }
     } catch (error) {
       // Silently fail - file is still saved
-      // Can't log error in hook context anyway
     }
   }
 

--- a/src/core/html-renderer.ts
+++ b/src/core/html-renderer.ts
@@ -432,7 +432,7 @@ export class HtmlRenderer {
       </div>
 
       <div class="footer">
-        <div>CASHIER: ${this.getMainModel(data)}</div>
+        <div>CASHIER: ${this.escapeHtml(this.getMainModel(data))}</div>
         <div class="footer-message">Thank you for building!</div>
         <div class="generated-by">
           Print your own <strong>Claude receipts</strong> with<br>

--- a/src/core/transcript-parser.ts
+++ b/src/core/transcript-parser.ts
@@ -30,7 +30,9 @@ export class TranscriptParser {
 
     const firstUserMessage = userMessages[0];
     const firstPrompt = this.extractPromptText(firstUserMessage);
-    const sessionSlug = firstUserMessage?.slug || "unknown-session";
+    const rawSlug = firstUserMessage?.slug ?? "";
+    const sessionSlug =
+      /^[a-zA-Z0-9_-]+$/.test(rawSlug) ? rawSlug : "unknown-session";
 
     // Calculate duration
     const timestamps = messages


### PR DESCRIPTION
## Summary

Two security vulnerabilities fixed, both exploitable via a malicious JSONL file placed under `~/.claude/projects/` (e.g. written by a compromised MCP server or attacker-controlled project directory):

- **Command injection** (`src/commands/generate.ts`): `openInBrowser` built shell strings with `exec()`, making session slugs from JSONL transcripts injectable. Replaced with `execFile()` so the path is passed as a direct OS argument, never interpreted by a shell.
- **HTML injection / XSS** (`src/core/html-renderer.ts`): The `CASHIER` line interpolated the model name without `escapeHtml()`, unlike every other user-derived field in the same template. A malicious `model` value in a transcript JSONL could execute JavaScript when the receipt is opened in the browser.
- **Slug validation** (`src/core/transcript-parser.ts`): Added an allowlist check (`/^[a-zA-Z0-9_-]+$/`) on the session slug before it's used as a filename, as defense in depth against the command injection path.

## Test plan
- [ ] Verify receipts still open in browser on macOS, Linux, and Windows after `execFile` change
- [ ] Verify HTML receipt renders correctly with normal model names
- [ ] Verify slugs with special characters fall back to `unknown-session`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)